### PR TITLE
Add mouse-controlled walls

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,10 @@
-# fluid
+# Fluid
+
+Keyboard controls:
+- `S`: Toggle between smoke and pressure rendering.
+- `J`: Enable or disable the jet.
+- `G`: Turn gravity on or off.
+- `R`: Reset the simulation.
+
+Mouse controls:
+- **Left click**: Toggle wall cells at the cursor position.

--- a/main/main.go
+++ b/main/main.go
@@ -65,6 +65,15 @@ func (g *Game) Update() error {
 		g.fluid.Reset()
 	}
 
+	if inpututil.IsMouseButtonJustPressed(ebiten.MouseButtonLeft) {
+		mx, my := ebiten.CursorPosition()
+		i := mx / factor
+		j := g.fluid.NumY - my/factor - 1
+		if i >= 0 && i < g.fluid.NumX && j >= 0 && j < g.fluid.NumY {
+			g.fluid.SetSolid(i, j, !g.fluid.IsSolid(i, j))
+		}
+	}
+
 	if g.jet {
 		x, y := 4.0, 0.0
 		size := 100
@@ -116,6 +125,18 @@ func (g *Game) Draw(screen *ebiten.Image) {
 				g.image.Pix[idx+1] = color.G
 				g.image.Pix[idx+2] = color.B
 				g.image.Pix[idx+3] = color.A
+			}
+		}
+	}
+
+	for i := range g.fluid.NumX {
+		for j := range g.fluid.NumY {
+			if g.fluid.IsSolid(i, g.fluid.NumY-j-1) {
+				idx := g.fluidToImageIndex(i, j)
+				g.image.Pix[idx+0] = 0
+				g.image.Pix[idx+1] = 0
+				g.image.Pix[idx+2] = 0
+				g.image.Pix[idx+3] = 0xff
 			}
 		}
 	}

--- a/pkg/fluid/walls.go
+++ b/pkg/fluid/walls.go
@@ -17,6 +17,17 @@ func (f *Fluid) SetSolid(i, j int, value bool) {
 	}
 }
 
+func (f *Fluid) IsSolid(i, j int) bool {
+	if i < 0 || i >= f.NumX {
+		panic(fmt.Sprintf("invalid x-index: %d", i))
+	}
+	if j < 0 || j >= f.NumY {
+		panic(fmt.Sprintf("invalid y-index: %d", j))
+	}
+	cell := i*f.NumY + j
+	return f.s[cell] == 0.0
+}
+
 func (f *Fluid) SetVelocity(i, j int, u, v float32) {
 	if i < 0 || i >= f.NumX {
 		panic(fmt.Sprintf("invalid x-index: %d", i))


### PR DESCRIPTION
## Summary
- allow toggling wall cells with the left mouse button
- show solid walls during rendering
- expose `IsSolid` helper
- document keyboard and mouse controls

## Testing
- `go vet ./...` *(fails: X11/extensions/Xrandr.h not found)*
- `go build ./...` *(fails: X11/extensions/Xrandr.h not found)*


------
https://chatgpt.com/codex/tasks/task_b_6848ed0e68f0832198e32f1ebef105b0