### PR TITLE
Add vorticity confinement force

### DIFF
--- a/pkg/fluid/confinement_test.go
+++ b/pkg/fluid/confinement_test.go
@@ -1,0 +1,28 @@
+package fluid
+
+import "testing"
+
+// Test that the vorticity confinement force adds velocity at regions with curl.
+func TestApplyVorticityConfinement(t *testing.T) {
+	f := New(1, 4, 4, 1)
+	for i := 0; i < f.NumX; i++ {
+		for j := 0; j < f.NumY; j++ {
+			f.SetSolid(i, j, false)
+		}
+	}
+	// Create a small 2x2 vortex in the middle of the grid.
+	f.SetVelocity(3, 2, 1, 0)
+	f.SetVelocity(2, 3, -1, 0)
+	f.SetVelocity(2, 2, 0, 1)
+	f.SetVelocity(3, 3, 0, -1)
+
+	f.Confinement = 5
+	idx := 2*f.NumY + 2 // Cell inside the vortex
+	u0 := f.u[idx]
+	v0 := f.v[idx]
+	f.applyVorticityConfinement(1)
+
+	if f.u[idx] == u0 && f.v[idx] == v0 {
+		t.Fatal("confinement force did not modify velocities")
+	}
+}


### PR DESCRIPTION
## Summary
- implement vorticity confinement in `Fluid` with adjustable `Confinement` strength
- integrate confinement force in `Simulate`
- add unit test verifying velocities change when confinement is applied
- install X11 headers to allow compiling GLFW dependencies

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_b_6848ed09204c8321aced51d68dcbf4c1