### PR TITLE
Fix Reset to clear all fields

### DIFF
--- a/pkg/fluid/walls.go
+++ b/pkg/fluid/walls.go
@@ -62,5 +62,9 @@ func (f *Fluid) SetGravity(on bool) {
 func (f *Fluid) Reset() {
 	fill(f.u, 0.0)
 	fill(f.v, 0.0)
+	fill(f.newU, 0.0)
+	fill(f.newV, 0.0)
+	fill(f.p, 0.0)
 	fill(f.m, 0.0)
+	fill(f.newM, 0.0)
 }


### PR DESCRIPTION
## Summary
- zero all velocity, pressure, and smoke buffers when resetting

## Testing
- `go vet ./...` *(fails: X11/extensions/Xrandr.h missing)*
- `go test ./...` *(fails: X11/extensions/Xrandr.h missing)*

------
https://chatgpt.com/codex/tasks/task_b_684901a0e1ec83219af0f4298e7f2563