### PR TITLE
Performance improvements

### DIFF
--- a/pkg/fluid/pressure.go
+++ b/pkg/fluid/pressure.go
@@ -5,9 +5,7 @@ import "math"
 func (f *Fluid) Pressure() ScalarField {
 	minValue := float32(math.MaxFloat32)
 	maxValue := float32(-(math.MaxFloat32 - 1))
-	pCopy := make([]float32, f.numCells)
 	for i := range f.numCells {
-		pCopy[i] = f.p[i]
 		if f.p[i] < minValue {
 			minValue = f.p[i]
 		}

--- a/pkg/fluid/smoke.go
+++ b/pkg/fluid/smoke.go
@@ -5,9 +5,7 @@ import "math"
 func (f *Fluid) Smoke() ScalarField {
 	minValue := float32(math.MaxFloat32)
 	maxValue := float32(-(math.MaxFloat32 - 1))
-	mCopy := make([]float32, f.numCells)
 	for i := range f.numCells {
-		mCopy[i] = f.m[i]
 		if f.m[i] < minValue {
 			minValue = f.m[i]
 		}


### PR DESCRIPTION
## Summary
- remove unused slice allocations when reading pressure and smoke fields
- reuse `ebiten.Image` instead of creating a new one each frame
- parallelize pixel generation for pressure, smoke, and wall rendering

## Testing
- `go test ./...` *(fails: X11/extensions/Xrandr.h missing)*

------
https://chatgpt.com/codex/tasks/task_b_684900181b4483219fae68e24fabbf8c