### PR TITLE
Add wall toggle and clearing controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@ Keyboard controls:
 - `J`: Enable or disable the jet.
 - `G`: Turn gravity on or off.
 - `R`: Reset the simulation.
+- Arrow keys `Up`, `Down`, `Left`, `Right`: Toggle the corresponding border wall.
+- `C`: Remove all walls except the active border walls.
 
 Mouse controls:
 - **Left click**: Toggle wall cells at the cursor position.


### PR DESCRIPTION
## Summary
- toggle boundary walls with arrow keys
- clear walls while keeping the active borders with C
- show wall status in the HUD
- document new controls

## Testing
- `go test ./...` *(fails: X11 headers missing)*

------
https://chatgpt.com/codex/tasks/task_b_6849048685748321ba930b7734249294