### PR TITLE
Fix boundary velocities when enabling walls

### DIFF
--- a/pkg/fluid/fluid.go
+++ b/pkg/fluid/fluid.go
@@ -128,13 +128,35 @@ func (f *Fluid) makeIncompressible(numIters uint, dt float32) {
 func (f *Fluid) handleBorders() {
 	n := f.NumY
 	parallelRange(0, f.NumX, func(i int) {
-		f.u[i*n+0] = f.u[i*n+1]               // top border
-		f.u[i*n+f.NumY-1] = f.u[i*n+f.NumY-2] // bottom border
+		// Top border (j == 0)
+		if f.s[i*n+0] == 0 || f.s[i*n+1] == 0 {
+			f.u[i*n+0] = 0
+		} else {
+			f.u[i*n+0] = f.u[i*n+1]
+		}
+
+		// Bottom border (j == NumY-1)
+		if f.s[i*n+f.NumY-1] == 0 || f.s[i*n+f.NumY-2] == 0 {
+			f.u[i*n+f.NumY-1] = 0
+		} else {
+			f.u[i*n+f.NumY-1] = f.u[i*n+f.NumY-2]
+		}
 	})
 
 	parallelRange(0, f.NumY, func(j int) {
-		f.v[0*n+j] = f.v[1*n+j]                   // left border
-		f.v[(f.NumX-1)*n+j] = f.v[(f.NumX-2)*n+j] // right border
+		// Left border (i == 0)
+		if f.s[0*n+j] == 0 || f.s[1*n+j] == 0 {
+			f.v[0*n+j] = 0
+		} else {
+			f.v[0*n+j] = f.v[1*n+j]
+		}
+
+		// Right border (i == NumX-1)
+		if f.s[(f.NumX-1)*n+j] == 0 || f.s[(f.NumX-2)*n+j] == 0 {
+			f.v[(f.NumX-1)*n+j] = 0
+		} else {
+			f.v[(f.NumX-1)*n+j] = f.v[(f.NumX-2)*n+j]
+		}
 	})
 }
 

--- a/pkg/fluid/walls.go
+++ b/pkg/fluid/walls.go
@@ -15,6 +15,24 @@ func (f *Fluid) SetSolid(i, j int, value bool) {
 	} else {
 		f.s[cell] = 1.0
 	}
+
+	// When a cell becomes solid, clear the associated velocities to
+	// immediately enforce the wall boundary. This prevents fluid from
+	// continuing to flow through or along newly created walls.
+	if value {
+		n := f.NumY
+		// Velocities are stored on a staggered grid. Zero out the four
+		// edges surrounding this cell, checking bounds to avoid
+		// out-of-range accesses.
+		f.u[i*n+j] = 0
+		if i+1 < f.NumX {
+			f.u[(i+1)*n+j] = 0
+		}
+		f.v[i*n+j] = 0
+		if j+1 < f.NumY {
+			f.v[i*n+j+1] = 0
+		}
+	}
 }
 
 func (f *Fluid) IsSolid(i, j int) bool {


### PR DESCRIPTION
## Summary
- zero velocities when converting cells to solids
- enforce solid boundaries in `handleBorders`

## Testing
- `go test ./pkg/...`

------
https://chatgpt.com/codex/tasks/task_b_68490934332483219315ada66163b057