### PR TITLE
Fix smoke border copying

### DIFF
--- a/pkg/fluid/fluid.go
+++ b/pkg/fluid/fluid.go
@@ -250,6 +250,7 @@ func (f *Fluid) sampleField(x, y float32, fld field) float32 {
 
 func (f *Fluid) advectSmoke(dt float32) {
 	// Copy border cells first so advection doesn't alter boundary values.
+	f.copyBorder(f.newM, f.m)
 
 	n := f.NumY
 	h := f.h


### PR DESCRIPTION
## Summary
- maintain boundary cells before advecting smoke

## Testing
- `go test ./pkg/...`
- `go build -o main.bin ./main` *(fails: fatal error: X11/extensions/Xrandr.h)*

------
https://chatgpt.com/codex/tasks/task_b_68490a691a888321acfaacf97e33280e