### PR TITLE
Ensure zero velocities for drawn walls

### DIFF
--- a/pkg/fluid/walls.go
+++ b/pkg/fluid/walls.go
@@ -32,6 +32,19 @@ func (f *Fluid) SetSolid(i, j int, value bool) {
 		if j+1 < f.NumY {
 			f.v[i*n+j+1] = 0
 		}
+
+		// Clear any in-flight velocities that may still reside in the
+		// temporary buffers used during simulation steps. Without this,
+		// advecting the velocity field would reintroduce non-zero values
+		// after the wall is drawn.
+		f.newU[i*n+j] = 0
+		if i+1 < f.NumX {
+			f.newU[(i+1)*n+j] = 0
+		}
+		f.newV[i*n+j] = 0
+		if j+1 < f.NumY {
+			f.newV[i*n+j+1] = 0
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary
- clear temporary velocity buffers when making a cell solid

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_b_68490b264f5c8321a68a815ebf6583b8