### PR TITLE
Reuse fluid simulation buffers and workers

### DIFF
--- a/pkg/fluid/fluid.go
+++ b/pkg/fluid/fluid.go
@@ -9,8 +9,10 @@ var (
 )
 
 type Fluid struct {
-	density float32
-	h       float32
+	density  float32
+	h        float32
+	bfecc    *bfeccWorkspace
+	parallel *parallelExecutor
 
 	NumX, NumY int
 	numCells   int
@@ -22,6 +24,9 @@ type Fluid struct {
 	M    []float32 // smoke
 	newM []float32
 
+	// Multigrid solver parameters
+	MultigridLevels int // Number of multigrid levels
+
 	// Strength of the vorticity confinement force. Set to 0 to disable.
 	Confinement float32
 
@@ -30,13 +35,34 @@ type Fluid struct {
 	PressureDamping    float32 // Damping factor to reduce pressure oscillations
 	TurbulenceStrength float32 // Small-scale turbulence for realism
 	SmokeAdvection     float32 // Enhanced smoke transport coefficient
-	
-	// Multigrid solver parameters
-	UseMultigrid    bool // Enable multigrid acceleration
-	MultigridLevels int  // Number of multigrid levels
+
+	UseMultigrid bool // Enable multigrid acceleration
 
 	// BFECC advection
 	UseBFECC bool // Enable Back and Forth Error Compensating and Correcting advection
+}
+
+type bfeccWorkspace struct {
+	origU, origV []float32
+	fwdU, fwdV   []float32
+	bwdU, bwdV   []float32
+	corrU, corrV []float32
+}
+
+func (f *Fluid) bfeccWorkspace() *bfeccWorkspace {
+	if f.bfecc == nil {
+		f.bfecc = &bfeccWorkspace{
+			origU: make([]float32, f.numCells),
+			origV: make([]float32, f.numCells),
+			fwdU:  make([]float32, f.numCells),
+			fwdV:  make([]float32, f.numCells),
+			bwdU:  make([]float32, f.numCells),
+			bwdV:  make([]float32, f.numCells),
+			corrU: make([]float32, f.numCells),
+			corrV: make([]float32, f.numCells),
+		}
+	}
+	return f.bfecc
 }
 
 func New(density float32, width, height int, h float32) *Fluid {
@@ -61,9 +87,9 @@ func New(density float32, width, height int, h float32) *Fluid {
 		PressureDamping:    1.0,   // Slight damping to reduce oscillations
 		TurbulenceStrength: 0.02,  // Small turbulence for realism
 		SmokeAdvection:     1.0,   // Standard smoke advection
-		UseMultigrid:    false, // Multigrid disabled by default
-		MultigridLevels: 2,    // 2-level multigrid (fine + coarse)
-		UseBFECC:        false,
+		UseMultigrid:       false, // Multigrid disabled by default
+		MultigridLevels:    2,     // 2-level multigrid (fine + coarse)
+		UseBFECC:           false,
 	}
 }
 
@@ -77,6 +103,15 @@ func fill[T any](slice []T, val T) {
 }
 
 func (f *Fluid) Simulate(dt float32) {
+	// Reuse one worker set across the simulation's dependent phases without
+	// leaving permanent background goroutines attached to a Fluid.
+	executor := newParallelExecutor(max(f.NumX, f.NumY))
+	f.parallel = executor
+	defer func() {
+		executor.close()
+		f.parallel = nil
+	}()
+
 	// Enhanced solver with fewer iterations but better visual results
 	numIters := uint(8) // Reduced from 20, compensated by other improvements
 
@@ -108,6 +143,14 @@ func (f *Fluid) Simulate(dt float32) {
 	}
 }
 
+func (f *Fluid) parallelRange(start, end int, fn func(i int)) {
+	if f.parallel == nil {
+		parallelRange(start, end, fn)
+		return
+	}
+	f.parallel.parallelRange(start, end, fn)
+}
+
 // Artificial viscosity for visual smoothness - reduces iteration requirements
 func (f *Fluid) applyViscosity(dt float32) {
 	if f.ViscosityDiffusion <= 0 {
@@ -121,7 +164,7 @@ func (f *Fluid) applyViscosity(dt float32) {
 	copy(f.newU, f.U)
 	copy(f.newV, f.V)
 
-	parallelRange(1, f.NumX-1, func(i int) {
+	f.parallelRange(1, f.NumX-1, func(i int) {
 		for j := 1; j < f.NumY-1; j++ {
 			if f.S[i*n+j] > 0 {
 				// Laplacian diffusion for U
@@ -157,11 +200,11 @@ func (f *Fluid) makeIncompressible(numIters uint, dt float32) {
 func (f *Fluid) solveSingleGrid(numIters uint, dt float32) {
 	cp := f.density * f.h / dt
 	tolerance := float32(1e-5)
-	
+
 	// Adaptive relaxation - start aggressive, become more conservative
 	initialRelaxation := Relaxation
 	minRelaxation := float32(1.2)
-	
+
 	var prevMaxDiv float32 = 1e10
 
 	for iter := uint(0); iter < numIters; iter++ {
@@ -175,12 +218,12 @@ func (f *Fluid) solveSingleGrid(numIters uint, dt float32) {
 		if maxDiv < tolerance {
 			break
 		}
-		
+
 		// If divergence is not improving, reduce relaxation
 		if maxDiv >= prevMaxDiv*0.99 && iter > 2 {
 			currentRelaxation *= 0.8
 		}
-		
+
 		prevMaxDiv = maxDiv
 	}
 }
@@ -229,13 +272,13 @@ func (f *Fluid) pressureJacobiIteration(relaxation, cp float32) float32 {
 			f.V[i*n+j+1] += sy1 * p
 		}
 	}
-	
+
 	return maxDiv
 }
 
 func (f *Fluid) handleBorders() {
 	n := f.NumY
-	parallelRange(0, f.NumX, func(i int) {
+	f.parallelRange(0, f.NumX, func(i int) {
 		// Top border (j == 0) - Enhanced extrapolation
 		if f.S[i*n+0] == 0 || f.S[i*n+1] == 0 {
 			f.U[i*n+0] = 0
@@ -261,7 +304,7 @@ func (f *Fluid) handleBorders() {
 		}
 	})
 
-	parallelRange(0, f.NumY, func(j int) {
+	f.parallelRange(0, f.NumY, func(j int) {
 		// Left border (i == 0)
 		if f.S[0*n+j] == 0 || f.S[1*n+j] == 0 {
 			f.V[0*n+j] = 0
@@ -297,7 +340,7 @@ func (f *Fluid) advectVelocity(dt float32) {
 	h := f.h
 	h2 := h / 2
 
-	parallelRange(1, f.NumX, func(i int) {
+	f.parallelRange(1, f.NumX, func(i int) {
 		for j := 1; j < f.NumY; j++ {
 
 			// u component
@@ -405,7 +448,7 @@ func (f *Fluid) advectSmoke(dt float32) {
 	h := f.h
 	h2 := 0.5 * h
 
-	parallelRange(1, f.NumX-1, func(i int) {
+	f.parallelRange(1, f.NumX-1, func(i int) {
 		for j := 1; j < f.NumY-1; j++ {
 
 			if f.S[i*n+j] != 0.0 {
@@ -416,15 +459,15 @@ func (f *Fluid) advectSmoke(dt float32) {
 
 				// Enhanced sampling with better interpolation
 				smokeValue := f.sampleField(x, y, fieldM)
-				
+
 				// Add slight diffusion for more natural smoke spread
 				if f.ViscosityDiffusion > 0 {
 					smokeDiffusion := f.ViscosityDiffusion * 0.3 * dt // Reduced factor for smoke
-					neighbors := f.M[(i-1)*n+j] + f.M[(i+1)*n+j] + 
-					            f.M[i*n+j-1] + f.M[i*n+j+1] - 4*f.M[i*n+j]
+					neighbors := f.M[(i-1)*n+j] + f.M[(i+1)*n+j] +
+						f.M[i*n+j-1] + f.M[i*n+j+1] - 4*f.M[i*n+j]
 					smokeValue += smokeDiffusion * neighbors
 				}
-				
+
 				f.newM[i*n+j] = max(smokeValue, 0.0) // Keep smoke non-negative
 			}
 		}
@@ -435,11 +478,11 @@ func (f *Fluid) advectSmoke(dt float32) {
 
 func (f *Fluid) copyBorder(dst, src []float32) {
 	n := f.NumY
-	parallelRange(0, f.NumX, func(i int) {
+	f.parallelRange(0, f.NumX, func(i int) {
 		dst[i*n+0] = src[i*n+0]
 		dst[i*n+f.NumY-1] = src[i*n+f.NumY-1]
 	})
-	parallelRange(0, f.NumY, func(j int) {
+	f.parallelRange(0, f.NumY, func(j int) {
 		dst[0*n+j] = src[0*n+j]
 		dst[(f.NumX-1)*n+j] = src[(f.NumX-1)*n+j]
 	})
@@ -497,22 +540,22 @@ func (f *Fluid) addTurbulence(dt float32) {
 	if f.TurbulenceStrength <= 0 {
 		return
 	}
-	
+
 	n := f.NumY
 	turbStrength := f.TurbulenceStrength * dt
-	
+
 	// Simple noise-based turbulence
-	parallelRange(1, f.NumX-1, func(i int) {
+	f.parallelRange(1, f.NumX-1, func(i int) {
 		for j := 1; j < f.NumY-1; j++ {
 			if f.S[i*n+j] > 0 {
 				// Pseudo-random noise based on position and time-like factor
-				seedU := float32(i*137 + j*241) * 0.01
-				seedV := float32(i*157 + j*263) * 0.01
-				
+				seedU := float32(i*137+j*241) * 0.01
+				seedV := float32(i*157+j*263) * 0.01
+
 				// Simple sine-based noise
 				noiseU := float32(math.Sin(float64(seedU))) * turbStrength
 				noiseV := float32(math.Sin(float64(seedV))) * turbStrength
-				
+
 				// Only apply to regions with existing flow
 				localVel := float32(math.Sqrt(float64(f.U[i*n+j]*f.U[i*n+j] + f.V[i*n+j]*f.V[i*n+j])))
 				if localVel > 0.1 {
@@ -529,7 +572,7 @@ func (f *Fluid) addTurbulence(dt float32) {
 func (f *Fluid) GetAdaptiveTimeStep(basedt float32) float32 {
 	maxVel := float32(0.0)
 	n := f.NumY
-	
+
 	// Find maximum velocity for CFL condition
 	for i := 1; i < f.NumX-1; i++ {
 		for j := 1; j < f.NumY-1; j++ {
@@ -541,18 +584,18 @@ func (f *Fluid) GetAdaptiveTimeStep(basedt float32) float32 {
 			}
 		}
 	}
-	
+
 	if maxVel == 0 {
 		return basedt
 	}
-	
+
 	// CFL condition: dt < h / maxVel
 	cflFactor := float32(0.8) // Safety factor
 	adaptivedt := cflFactor * f.h / maxVel
-	
+
 	// Clamp to reasonable range
 	adaptivedt = max(min(adaptivedt, basedt*2.0), basedt*0.1)
-	
+
 	return adaptivedt
 }
 
@@ -560,36 +603,36 @@ func (f *Fluid) GetAdaptiveTimeStep(basedt float32) float32 {
 func (f *Fluid) solveMultigridVCycle(numIters uint, dt float32) {
 	cp := f.density * f.h / dt
 	tolerance := float32(1e-5)
-	
+
 	// Pre-smoothing iterations on fine grid
 	preSmoothIters := uint(3)
-	// Post-smoothing iterations on fine grid  
+	// Post-smoothing iterations on fine grid
 	postSmoothIters := uint(3)
-	
+
 	for iter := uint(0); iter < numIters; iter++ {
 		// Pre-smooth on fine grid
 		maxDiv := float32(0.0)
 		for smooth := uint(0); smooth < preSmoothIters; smooth++ {
 			maxDiv = f.pressureJacobiIteration(1.5, cp)
 		}
-		
+
 		if maxDiv < tolerance {
 			break
 		}
-		
+
 		// Compute residual and restrict to coarse grid
 		residual := f.computePressureResidual()
 		coarseRHS := f.restrictResidual(residual)
-		
+
 		// Solve on coarse grid (2x2 coarsening)
 		coarseCorrection := f.solveCoarseGrid(coarseRHS)
-		
+
 		// Prolongate correction back to fine grid
 		correction := f.prolongateCorrection(coarseCorrection)
-		
+
 		// Apply correction to fine grid pressure
 		f.applePressureCorrection(correction, cp)
-		
+
 		// Post-smooth on fine grid
 		for smooth := uint(0); smooth < postSmoothIters; smooth++ {
 			f.pressureJacobiIteration(1.2, cp)
@@ -601,32 +644,32 @@ func (f *Fluid) solveMultigridVCycle(numIters uint, dt float32) {
 func (f *Fluid) computePressureResidual() []float32 {
 	n := f.NumY
 	residual := make([]float32, f.numCells)
-	
+
 	for i := 1; i < f.NumX-1; i++ {
 		for j := 1; j < f.NumY-1; j++ {
 			if f.S[i*n+j] == 0 {
 				continue
 			}
-			
+
 			// Compute divergence (RHS of pressure equation)
 			div := f.U[(i+1)*n+j] - f.U[i*n+j] + f.V[i*n+j+1] - f.V[i*n+j]
-			
+
 			// Compute Laplacian of pressure (LHS)
 			sx0 := f.S[(i-1)*n+j]
 			sx1 := f.S[(i+1)*n+j]
 			sy0 := f.S[i*n+j-1]
 			sy1 := f.S[i*n+j+1]
-			
-			laplacian := sx0*(f.p[(i-1)*n+j] - f.p[i*n+j]) +
-			            sx1*(f.p[(i+1)*n+j] - f.p[i*n+j]) +
-			            sy0*(f.p[i*n+j-1] - f.p[i*n+j]) +
-			            sy1*(f.p[i*n+j+1] - f.p[i*n+j])
-			
+
+			laplacian := sx0*(f.p[(i-1)*n+j]-f.p[i*n+j]) +
+				sx1*(f.p[(i+1)*n+j]-f.p[i*n+j]) +
+				sy0*(f.p[i*n+j-1]-f.p[i*n+j]) +
+				sy1*(f.p[i*n+j+1]-f.p[i*n+j])
+
 			// Residual = RHS - LHS
 			residual[i*n+j] = -div - laplacian
 		}
 	}
-	
+
 	return residual
 }
 
@@ -636,30 +679,30 @@ func (f *Fluid) restrictResidual(fineResidual []float32) []float32 {
 	coarseNY := (f.NumY + 1) / 2
 	coarseSize := coarseNX * coarseNY
 	coarseRHS := make([]float32, coarseSize)
-	
+
 	// Full-weighting restriction - average neighboring points
 	for i := 1; i < coarseNX-1; i++ {
 		for j := 1; j < coarseNY-1; j++ {
 			fineI := i * 2
 			fineJ := j * 2
-			
+
 			if fineI < f.NumX-1 && fineJ < f.NumY-1 {
 				// Full weighting: center weight 0.25, neighbors 0.125, corners 0.0625
 				center := fineResidual[fineI*f.NumY+fineJ] * 0.25
-				neighbors := (fineResidual[(fineI-1)*f.NumY+fineJ] + 
-				             fineResidual[(fineI+1)*f.NumY+fineJ] + 
-				             fineResidual[fineI*f.NumY+fineJ-1] + 
-				             fineResidual[fineI*f.NumY+fineJ+1]) * 0.125
-				corners := (fineResidual[(fineI-1)*f.NumY+fineJ-1] + 
-				           fineResidual[(fineI+1)*f.NumY+fineJ-1] + 
-				           fineResidual[(fineI-1)*f.NumY+fineJ+1] + 
-				           fineResidual[(fineI+1)*f.NumY+fineJ+1]) * 0.0625
-				
+				neighbors := (fineResidual[(fineI-1)*f.NumY+fineJ] +
+					fineResidual[(fineI+1)*f.NumY+fineJ] +
+					fineResidual[fineI*f.NumY+fineJ-1] +
+					fineResidual[fineI*f.NumY+fineJ+1]) * 0.125
+				corners := (fineResidual[(fineI-1)*f.NumY+fineJ-1] +
+					fineResidual[(fineI+1)*f.NumY+fineJ-1] +
+					fineResidual[(fineI-1)*f.NumY+fineJ+1] +
+					fineResidual[(fineI+1)*f.NumY+fineJ+1]) * 0.0625
+
 				coarseRHS[i*coarseNY+j] = center + neighbors + corners
 			}
 		}
 	}
-	
+
 	return coarseRHS
 }
 
@@ -668,16 +711,16 @@ func (f *Fluid) solveCoarseGrid(rhs []float32) []float32 {
 	coarseNX := (f.NumX + 1) / 2
 	coarseNY := (f.NumY + 1) / 2
 	coarseSize := coarseNX * coarseNY
-	
+
 	coarseP := make([]float32, coarseSize)
 	coarseS := make([]float32, coarseSize)
-	
+
 	// Create coarse solid mask
 	for i := 0; i < coarseNX; i++ {
 		for j := 0; j < coarseNY; j++ {
 			fineI := i * 2
 			fineJ := j * 2
-			
+
 			if fineI < f.NumX && fineJ < f.NumY {
 				coarseS[i*coarseNY+j] = f.S[fineI*f.NumY+fineJ]
 			} else {
@@ -685,42 +728,42 @@ func (f *Fluid) solveCoarseGrid(rhs []float32) []float32 {
 			}
 		}
 	}
-	
+
 	// Solve coarse system with more iterations (since it's smaller)
 	coarseIters := 40
 	relaxation := float32(1.6)
-	
+
 	for iter := 0; iter < coarseIters; iter++ {
 		for i := 1; i < coarseNX-1; i++ {
 			for j := 1; j < coarseNY-1; j++ {
 				if coarseS[i*coarseNY+j] == 0 {
 					continue
 				}
-				
+
 				sx0 := coarseS[(i-1)*coarseNY+j]
 				sx1 := coarseS[(i+1)*coarseNY+j]
 				sy0 := coarseS[i*coarseNY+j-1]
 				sy1 := coarseS[i*coarseNY+j+1]
 				s := sx0 + sx1 + sy0 + sy1
-				
+
 				if s == 0 {
 					continue
 				}
-				
+
 				// Solve: Laplacian(p) = rhs
-				laplacian := sx0*(coarseP[(i-1)*coarseNY+j] - coarseP[i*coarseNY+j]) +
-				            sx1*(coarseP[(i+1)*coarseNY+j] - coarseP[i*coarseNY+j]) +
-				            sy0*(coarseP[i*coarseNY+j-1] - coarseP[i*coarseNY+j]) +
-				            sy1*(coarseP[i*coarseNY+j+1] - coarseP[i*coarseNY+j])
-				
+				laplacian := sx0*(coarseP[(i-1)*coarseNY+j]-coarseP[i*coarseNY+j]) +
+					sx1*(coarseP[(i+1)*coarseNY+j]-coarseP[i*coarseNY+j]) +
+					sy0*(coarseP[i*coarseNY+j-1]-coarseP[i*coarseNY+j]) +
+					sy1*(coarseP[i*coarseNY+j+1]-coarseP[i*coarseNY+j])
+
 				residual := rhs[i*coarseNY+j] - laplacian
 				correction := -residual / s * relaxation
-				
+
 				coarseP[i*coarseNY+j] += correction
 			}
 		}
 	}
-	
+
 	return coarseP
 }
 
@@ -728,7 +771,7 @@ func (f *Fluid) solveCoarseGrid(rhs []float32) []float32 {
 func (f *Fluid) prolongateCorrection(coarseCorrection []float32) []float32 {
 	correction := make([]float32, f.numCells)
 	coarseNY := (f.NumY + 1) / 2
-	
+
 	// Bilinear interpolation from coarse to fine
 	for i := 0; i < f.NumX; i++ {
 		for j := 0; j < f.NumY; j++ {
@@ -736,24 +779,24 @@ func (f *Fluid) prolongateCorrection(coarseCorrection []float32) []float32 {
 			coarseI := i / 2
 			coarseJ := j / 2
 			coarseNX := (f.NumX + 1) / 2
-			
+
 			if coarseI >= coarseNX-1 || coarseJ >= coarseNY-1 {
 				continue
 			}
-			
+
 			// Interpolation weights
 			fracI := float32(i%2) * 0.5
 			fracJ := float32(j%2) * 0.5
-			
+
 			// Bilinear interpolation
-			correction[i*f.NumY+j] = 
+			correction[i*f.NumY+j] =
 				(1-fracI)*(1-fracJ)*coarseCorrection[coarseI*coarseNY+coarseJ] +
-				fracI*(1-fracJ)*coarseCorrection[(coarseI+1)*coarseNY+coarseJ] +
-				(1-fracI)*fracJ*coarseCorrection[coarseI*coarseNY+coarseJ+1] +
-				fracI*fracJ*coarseCorrection[(coarseI+1)*coarseNY+coarseJ+1]
+					fracI*(1-fracJ)*coarseCorrection[(coarseI+1)*coarseNY+coarseJ] +
+					(1-fracI)*fracJ*coarseCorrection[coarseI*coarseNY+coarseJ+1] +
+					fracI*fracJ*coarseCorrection[(coarseI+1)*coarseNY+coarseJ+1]
 		}
 	}
-	
+
 	return correction
 }
 
@@ -912,10 +955,11 @@ func (f *Fluid) advectVelocityBFECC(dt float32) {
 	n := f.NumY
 	h := f.h
 	h2 := h / 2
+	workspace := f.bfeccWorkspace()
 
 	// Save original
-	origU := make([]float32, f.numCells)
-	origV := make([]float32, f.numCells)
+	origU := workspace.origU
+	origV := workspace.origV
 	copy(origU, f.U)
 	copy(origV, f.V)
 
@@ -923,8 +967,8 @@ func (f *Fluid) advectVelocityBFECC(dt float32) {
 	f.advectVelocity(dt)
 
 	// Save forward result
-	fwdU := make([]float32, f.numCells)
-	fwdV := make([]float32, f.numCells)
+	fwdU := workspace.fwdU
+	fwdV := workspace.fwdV
 	copy(fwdU, f.U)
 	copy(fwdV, f.V)
 
@@ -935,12 +979,12 @@ func (f *Fluid) advectVelocityBFECC(dt float32) {
 	copy(f.U, origU)
 	copy(f.V, origV)
 
-	bwdU := make([]float32, f.numCells)
-	bwdV := make([]float32, f.numCells)
+	bwdU := workspace.bwdU
+	bwdV := workspace.bwdV
 	f.copyBorder(bwdU, fwdU)
 	f.copyBorder(bwdV, fwdV)
 
-	parallelRange(1, f.NumX, func(i int) {
+	f.parallelRange(1, f.NumX, func(i int) {
 		for j := 1; j < f.NumY; j++ {
 			// u component backward advection
 			if f.S[i*n+j] != 0 && f.S[(i-1)*n+j] != 0 && j < f.NumY-1 {
@@ -966,8 +1010,8 @@ func (f *Fluid) advectVelocityBFECC(dt float32) {
 	})
 
 	// Pass 3: Compute error and corrected field
-	corrU := make([]float32, f.numCells)
-	corrV := make([]float32, f.numCells)
+	corrU := workspace.corrU
+	corrV := workspace.corrV
 	copy(corrU, origU)
 	copy(corrV, origV)
 
@@ -998,23 +1042,25 @@ func (f *Fluid) advectSmokeBFECC(dt float32) {
 	n := f.NumY
 	h := f.h
 	h2 := 0.5 * h
+	workspace := f.bfeccWorkspace()
 
-	// Save original
-	origM := make([]float32, f.numCells)
+	// Velocity advection has completed, so the smoke pass can reuse its first
+	// four scratch buffers.
+	origM := workspace.origU
 	copy(origM, f.M)
 
 	// Pass 1: Forward advect smoke
 	f.advectSmoke(dt)
 
 	// Save forward result
-	fwdM := make([]float32, f.numCells)
+	fwdM := workspace.origV
 	copy(fwdM, f.M)
 
 	// Pass 2: Backward advect the forward result
-	bwdM := make([]float32, f.numCells)
+	bwdM := workspace.fwdU
 	f.copyBorder(bwdM, fwdM)
 
-	parallelRange(1, f.NumX-1, func(i int) {
+	f.parallelRange(1, f.NumX-1, func(i int) {
 		for j := 1; j < f.NumY-1; j++ {
 			if f.S[i*n+j] != 0 {
 				u := (f.U[i*n+j] + f.U[(i+1)*n+j]) * 0.5 * f.SmokeAdvection
@@ -1027,7 +1073,7 @@ func (f *Fluid) advectSmokeBFECC(dt float32) {
 	})
 
 	// Pass 3: Error compensate
-	corrM := make([]float32, f.numCells)
+	corrM := workspace.fwdV
 	copy(corrM, origM)
 	for i := 1; i < f.NumX-1; i++ {
 		for j := 1; j < f.NumY-1; j++ {
@@ -1122,24 +1168,24 @@ func (f *Fluid) clampToNeighbors(val float32, src []float32, i, j int) float32 {
 // Apply pressure correction and update velocities
 func (f *Fluid) applePressureCorrection(correction []float32, cp float32) {
 	n := f.NumY
-	
+
 	for i := 1; i < f.NumX-1; i++ {
 		for j := 1; j < f.NumY-1; j++ {
 			if f.S[i*n+j] == 0 {
 				continue
 			}
-			
+
 			// Apply correction to pressure
 			f.p[i*n+j] += correction[i*n+j] * cp
-			
+
 			// Update velocities based on pressure gradient
 			sx0 := f.S[(i-1)*n+j]
 			sx1 := f.S[(i+1)*n+j]
 			sy0 := f.S[i*n+j-1]
 			sy1 := f.S[i*n+j+1]
-			
+
 			pressureCorrection := correction[i*n+j]
-			
+
 			f.U[i*n+j] -= sx0 * pressureCorrection
 			f.U[(i+1)*n+j] += sx1 * pressureCorrection
 			f.V[i*n+j] -= sy0 * pressureCorrection

--- a/pkg/fluid/fluid_bench_test.go
+++ b/pkg/fluid/fluid_bench_test.go
@@ -20,6 +20,7 @@ func newBenchFluid() *Fluid {
 func BenchmarkSimulate(b *testing.B) {
 	f := newBenchFluid()
 	dt := float32(1.0 / 120.0)
+	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		f.Simulate(dt)
@@ -32,6 +33,7 @@ func BenchmarkSimulateWithJet(b *testing.B) {
 	dt := float32(1.0 / 120.0)
 	n := f.NumY
 	jetVel := float32(4.0)
+	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		for j := f.NumY/2 - 50; j < f.NumY/2+50; j++ {
@@ -46,9 +48,11 @@ func BenchmarkSimulateWithJet(b *testing.B) {
 func BenchmarkSimulateBFECC(b *testing.B) {
 	f := newBenchFluid()
 	f.UseBFECC = true
+	f.bfeccWorkspace()
 	dt := float32(1.0 / 120.0)
 	n := f.NumY
 	jetVel := float32(4.0)
+	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		for j := f.NumY/2 - 50; j < f.NumY/2+50; j++ {

--- a/pkg/fluid/parallel.go
+++ b/pkg/fluid/parallel.go
@@ -5,6 +5,76 @@ import (
 	"sync"
 )
 
+type parallelJob struct {
+	fn         func(int)
+	start, end int
+}
+
+type parallelExecutor struct {
+	jobs        chan parallelJob
+	phase       sync.WaitGroup
+	workers     sync.WaitGroup
+	workerCount int
+}
+
+func newParallelExecutor(limit int) *parallelExecutor {
+	workerCount := min(runtime.GOMAXPROCS(0), limit)
+	executor := &parallelExecutor{workerCount: workerCount}
+	if workerCount <= 1 {
+		return executor
+	}
+	executor.jobs = make(chan parallelJob)
+	executor.workers.Add(workerCount - 1)
+	for range workerCount - 1 {
+		go executor.run()
+	}
+	return executor
+}
+
+func (e *parallelExecutor) run() {
+	defer e.workers.Done()
+	for job := range e.jobs {
+		for i := job.start; i < job.end; i++ {
+			job.fn(i)
+		}
+		e.phase.Done()
+	}
+}
+
+func (e *parallelExecutor) parallelRange(start, end int, fn func(i int)) {
+	total := end - start
+	if total <= 0 {
+		return
+	}
+	if e.workerCount <= 1 {
+		for i := start; i < end; i++ {
+			fn(i)
+		}
+		return
+	}
+	workers := min(e.workerCount, total)
+	chunk := (total + workers - 1) / workers
+	background := workers - 1
+	e.phase.Add(background)
+	for worker := 0; worker < background; worker++ {
+		jobStart := start + worker*chunk
+		jobEnd := min(jobStart+chunk, end)
+		e.jobs <- parallelJob{start: jobStart, end: jobEnd, fn: fn}
+	}
+	for i := start + background*chunk; i < end; i++ {
+		fn(i)
+	}
+	e.phase.Wait()
+}
+
+func (e *parallelExecutor) close() {
+	if e.jobs == nil {
+		return
+	}
+	close(e.jobs)
+	e.workers.Wait()
+}
+
 // parallelRange executes fn for each i in [start,end). The range is split among
 // available CPUs.
 func parallelRange(start, end int, fn func(i int)) {

--- a/pkg/fluid/parallel_test.go
+++ b/pkg/fluid/parallel_test.go
@@ -1,0 +1,62 @@
+package fluid
+
+import (
+	"fmt"
+	"sync/atomic"
+	"testing"
+)
+
+func TestParallelExecutor(t *testing.T) {
+	for _, limit := range []int{1, 4} {
+		t.Run(fmt.Sprintf("limit=%d", limit), func(t *testing.T) {
+			executor := newParallelExecutor(limit)
+			defer executor.close()
+
+			const phases = 3
+			counts := make([]atomic.Int32, 257)
+			for range phases {
+				executor.parallelRange(3, len(counts)-4, func(i int) {
+					counts[i].Add(1)
+				})
+			}
+
+			for i := range counts {
+				want := int32(0)
+				if i >= 3 && i < len(counts)-4 {
+					want = phases
+				}
+				if got := counts[i].Load(); got != want {
+					t.Fatalf("counts[%d] = %d, want %d", i, got, want)
+				}
+			}
+		})
+	}
+}
+
+func BenchmarkParallelRange(b *testing.B) {
+	const rows = 251
+	values := make([]uint64, 300*rows)
+	work := func(i int) {
+		offset := i * rows
+		for j := range rows {
+			values[offset+j]++
+		}
+	}
+
+	b.Run("per-call-workers", func(b *testing.B) {
+		b.ReportAllocs()
+		for range b.N {
+			parallelRange(0, len(values)/rows, work)
+		}
+	})
+
+	b.Run("reused-workers", func(b *testing.B) {
+		executor := newParallelExecutor(len(values) / rows)
+		defer executor.close()
+		b.ReportAllocs()
+		b.ResetTimer()
+		for range b.N {
+			executor.parallelRange(0, len(values)/rows, work)
+		}
+	})
+}


### PR DESCRIPTION
## Summary

- lazily allocate and reuse BFECC grid workspaces instead of allocating twelve full-grid slices every frame
- reuse the velocity workspace during the later smoke pass, retaining eight scratch grids rather than twelve
- create one simulation-scoped worker executor and reuse it across dependent phases
- have the caller participate alongside `GOMAXPROCS-1` background workers, avoiding oversubscription and permanent goroutines
- add executor correctness coverage and representative allocation benchmarks

The BFECC workspace is allocated only when BFECC is used. For the benchmark's 302x253 internal grid it retains about 2.33 MiB, replacing roughly 3.59 MiB of transient allocation on every frame.

## Analysis tools

- `fieldalignment`: identified eight bytes of avoidable padding after adding the runtime fields; scalar tail fields were regrouped without moving the hot grid slices
- compiler escape/inlining diagnostics via `go test ./pkg/fluid -run='^$' -gcflags='github.com/TheFellow/fluid/pkg/fluid=-m=2'`: showed each `parallelRange` closure and wait group escaping
- `pprof -alloc_objects`: attributed 86.7% of sampled allocated objects to `parallelRange`
- `pprof -alloc_space`: attributed 64.5% of sampled bytes to `advectVelocityBFECC` and 32.9% to `advectSmokeBFECC`
- SSA bounds-check diagnostics were also reviewed; no speculative bounds-check rewrite is included

## Benchmark verification

A/B results compare this branch with `origin/main` on darwin/arm64 (Apple M4 Max). Twelve samples were alternated between base and PR to limit thermal/scheduler bias, using `-benchtime=300ms`, `-benchmem`, and `benchstat`.

| Benchmark | Time, main -> PR | Time result | Bytes/op, main -> PR | Allocs/op, main -> PR |
| --- | ---: | --- | ---: | ---: |
| `Simulate` | 1.045 ms -> 1.049 ms | no significant change (`p=0.887`) | 14.397 KiB -> 1.679 KiB (-88.34%) | 510 -> 33 (-93.53%) |
| `SimulateWithJet` | 5.088 ms -> 5.172 ms | no significant change (`p=0.128`) | 14.323 KiB -> 1.519 KiB (-89.39%) | 510 -> 33 (-93.53%) |
| `SimulateBFECC` | 8.751 ms -> 8.632 ms | no significant change (`p=0.078`) | 3677.927 KiB -> 2.771 KiB (-99.92%) | 1066 -> 48 (-95.50%) |

The representative `BenchmarkParallelRange` comparison also moves from about 16.0 us, 912 B, and 33 allocs/op with per-call workers to about 15.0 us, 0 B, and 0 allocs/op with reused workers.

## Validation

- `go test ./...`
- `GOMAXPROCS=1 go test ./...`
- `go test ./pkg/fluid -count=5`
- `go test -race ./pkg/fluid`
- `go vet ./...`
- `git diff --check`

A focused `golangci-lint` run still reports two pre-existing findings: an ineffectual relaxation assignment in `fluid.go` and an empty test branch in `fluid_test.go`; this PR does not expand into those behavioral cleanups.